### PR TITLE
Fix transitive trusts lookup

### DIFF
--- a/Sharphound2/Enumeration/DomainTrustEnumeration.cs
+++ b/Sharphound2/Enumeration/DomainTrustEnumeration.cs
@@ -91,6 +91,10 @@ namespace Sharphound2.Enumeration
                 {
                     trust.IsTransitive = false;
                 }
+                else
+                {
+                    trust.IsTransitive = true;
+                }
                     
                 yield return trust;
             }


### PR DESCRIPTION
Hi,

While working on the python-based ingestor of BloodHound, I noticed an inconsistency with the Python version and SharpHound. It seems that trusts are always marked as non-transitive.
I believe this stems from the `IsTransitive` attribute only being set to False if the trust is indeed non-transitive, but if the non-transitive flag is not set the attribute is not modified. I'm not an expert on C# but I'm assuming that if uninitialized the variable defaults to false.
Anyway, adding an `else` statement seems to have fixed it for my case.