### PR TITLE
Fix ArgumentException on invalid SID

### DIFF
--- a/Sharphound2/Utils.cs
+++ b/Sharphound2/Utils.cs
@@ -231,7 +231,17 @@ namespace Sharphound2
         public string SidToDomainName(string sid, string domainController = null)
         {
             Debug($"Creating SecurityIdentifier from {sid}");
-            var id = new SecurityIdentifier(sid);
+            SecurityIdentifier id;
+            try
+            {
+                id = new SecurityIdentifier(sid);
+            }
+            catch
+            {
+                Verbose($"Unable to create SecurityIdentifier from {sid}");
+                return null;
+            }
+
             if (id.AccountDomainSid == null)
             {
                 Debug($"SecurityIdentifier was null");


### PR DESCRIPTION
These changes fix a `System.ArgumentException` in `SidToDomainName` when the SID is invalid.

This occurs when looking up foreign security principals with a name conflict. When this happens SharpHound will attempt to create a `SecurityIdenifier` from a string similar to **S-1-5-21-123456789-123456789-123456789-123\0ACNF:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee** which will fail due to the invalid format.