### PR TITLE
Fix LdapPass Usage

### DIFF
--- a/Sharphound2/Sharphound.cs
+++ b/Sharphound2/Sharphound.cs
@@ -194,7 +194,7 @@ Connection Options:
     --LdapUser (Default: null)
         User to connect to LDAP with
 
-    --LdapPassword (Default: null)
+    --LdapPass (Default: null)
         Password for the user to connect to LDAP with
 
 Performance Tuning:


### PR DESCRIPTION
The code requires LdapPass, but GetUsage() displays "--LdapPassword".