### PR TITLE
Update Utils.cs

### DIFF
--- a/Sharphound2/Utils.cs
+++ b/Sharphound2/Utils.cs
@@ -258,7 +258,7 @@ namespace Sharphound2
             }
 
             Debug($"Searching for sid in AD by securityidentifier");
-            entry = DoSearch($"(securityidentifier={dSid})", SearchScope.Subtree, new[] { "cn" }, useGc: true)
+            entry = DoSearch($"(&(objectClass=trustedDomain)(securityidentifier={dSid}))", SearchScope.Subtree, new[] { "cn" }, useGc: true)
                 .DefaultIfEmpty(null).FirstOrDefault();
 
             if (entry != null)


### PR DESCRIPTION
Added objectClass=trustedDomain to securityIdentifier LDAP Query. Without objectClass the query takes ages to complete on large DBs and with parallelization this has the potential to be a Denial of Service attack.