### PR TITLE
Collection of lastlogontimestamp attribute

### DIFF
--- a/Sharphound2/Enumeration/LdapFilter.cs
+++ b/Sharphound2/Enumeration/LdapFilter.cs
@@ -56,7 +56,7 @@ namespace Sharphound2.Enumeration
                 filterparts.Add("(|(samaccounttype=268435456)(samaccounttype=268435457)(samaccounttype=536870912)(samaccounttype=536870913)(samaccounttype=805306368)(samaccounttype=805306369)(objectclass=domain)(objectclass=organizationalUnit)(objectcategory=groupPolicyContainer))");
                 props.AddRange(new[]
                 {
-                    "samaccountname", "distinguishedname", "samaccounttype", "pwdlastset", "lastlogon", "objectsid",
+                    "samaccountname", "distinguishedname", "samaccounttype", "pwdlastset", "lastlogon", "lastlogontimestamp", "objectsid",
                     "sidhistory", "useraccountcontrol", "dnshostname", "operatingsystem",
                     "operatingsystemservicepack", "serviceprincipalname", "displayname", "mail", "title",
                     "homedirectory","description","admincount","userpassword","gpcfilesyspath","objectclass",

--- a/Sharphound2/Enumeration/ObjectPropertyHelpers.cs
+++ b/Sharphound2/Enumeration/ObjectPropertyHelpers.cs
@@ -143,6 +143,7 @@ namespace Sharphound2.Enumeration
             //var history = entry.GetPropBytes("sidhistory");
             //obj.SidHistory = history != null ? new SecurityIdentifier(history, 0).Value : "";
             obj.Properties.Add("lastlogon", ConvertToUnixEpoch(entry.GetProp("lastlogon")));
+            obj.Properties.Add("lastlogontimestamp", ConvertToUnixEpoch(entry.GetProp("lastlogontimestamp")));
             obj.Properties.Add("pwdlastset", ConvertToUnixEpoch(entry.GetProp("pwdlastset")));
             var spn = entry.GetPropArray("serviceprincipalname");
             obj.Properties.Add("serviceprincipalnames", spn);
@@ -212,6 +213,7 @@ namespace Sharphound2.Enumeration
             obj.Properties.Add("enabled", enabled);
             obj.Properties.Add("unconstraineddelegation", unconstrained);
             obj.Properties.Add("lastlogon", ConvertToUnixEpoch(entry.GetProp("lastlogon")));
+            obj.Properties.Add("lastlogontimestamp", ConvertToUnixEpoch(entry.GetProp("lastlogontimestamp")));
             obj.Properties.Add("pwdlastset", ConvertToUnixEpoch(entry.GetProp("pwdlastset")));
             obj.Properties.Add("serviceprincipalnames", entry.GetPropArray("serviceprincipalname"));
             var os = entry.GetProp("operatingsystem");


### PR DESCRIPTION
Instead of lastlogon lastlogontimestamp should be used as the lastlogon attribute is not replicated between DCs.

Should also be adjusted in BloodHound.