### PR TITLE
Remove verbose debug output

### DIFF
--- a/Sharphound2/Enumeration/EnumerationRunner.cs
+++ b/Sharphound2/Enumeration/EnumerationRunner.cs
@@ -82,8 +82,6 @@ namespace Sharphound2.Enumeration
                     if (resolved == null)
                         continue;
 
-                    Console.WriteLine(resolved.BloodHoundDisplay);
-                    Console.WriteLine(resolved.ObjectType);
                     var domain = Utils.ConvertDnToDomain(entry.DistinguishedName);
                     var sid = entry.GetSid();
 


### PR DESCRIPTION
Two console writes added in 2fd7175ae03dcb63fbcd4c8430b85c0c7aba7373 cause information about every single enumerated object to be output to the console. This is incredibly verbose!

Presumably this was added for debug purposes, but never removed.