### PR TITLE
Improve trusts and entire forest enumeration

### DIFF
--- a/Sharphound2/Enumeration/TrustHelpers.cs
+++ b/Sharphound2/Enumeration/TrustHelpers.cs
@@ -70,7 +70,7 @@ namespace Sharphound2.Enumeration
                 var trust = new Trust();
 
                 var data = array[i];
-                var trustFlags = (Flags)data.Flags;
+                var trustFlags = (TrustFlags)data.Flags;
                 var trustAttribs = (TrustAttrib)data.TrustAttributes;
                 
                 /*
@@ -79,15 +79,15 @@ namespace Sharphound2.Enumeration
                 */
 
                 // the domain itself
-                if ((trustFlags & Flags.DsDomainPrimary) == Flags.DsDomainPrimary)
+                if ((trustFlags & TrustFlags.DsDomainPrimary) == TrustFlags.DsDomainPrimary)
                     continue;
 
                 if (data.DnsDomainName == null)
                     continue;
 
                 trust.TargetName = data.DnsDomainName;
-                var inbound = (trustFlags & Flags.DsDomainDirectInbound) == Flags.DsDomainDirectInbound;
-                var outbound = (trustFlags & Flags.DsDomainDirectOutbound) == Flags.DsDomainDirectOutbound;
+                var inbound = (trustFlags & TrustFlags.DsDomainDirectInbound) == TrustFlags.DsDomainDirectInbound;
+                var outbound = (trustFlags & TrustFlags.DsDomainDirectOutbound) == TrustFlags.DsDomainDirectOutbound;
 
                 if (inbound && outbound)
                 {
@@ -107,12 +107,12 @@ namespace Sharphound2.Enumeration
                     continue;
                 }
 
-                if (((trustFlags & Flags.DsDomainTreeRoot) == Flags.DsDomainTreeRoot) && ((trustFlags & Flags.DsDomainInForest) == Flags.DsDomainInForest)
+                if (((trustFlags & TrustFlags.DsDomainTreeRoot) == TrustFlags.DsDomainTreeRoot) && ((trustFlags & TrustFlags.DsDomainInForest) == TrustFlags.DsDomainInForest)
                     || array[data.ParentIndex].DnsDomainName.ToUpper() == resolved.BloodHoundDisplay)
                 {
                     trust.TrustType = "ParentChild";
                 }
-                else if ((trustFlags & Flags.DsDomainInForest) == Flags.DsDomainInForest)
+                else if ((trustFlags & TrustFlags.DsDomainInForest) == TrustFlags.DsDomainInForest)
                 {
                     trust.TrustType = "CrossLink";
                 }
@@ -144,7 +144,7 @@ namespace Sharphound2.Enumeration
 
         #region PINVOKE
         [Flags]
-        private enum Flags : uint
+        private enum TrustFlags : uint
         {
             DsDomainInForest = 0x0001,  // Domain is a member of the forest
             DsDomainDirectOutbound = 0x0002,  // Domain is directly trusted

--- a/Sharphound2/JsonObjects/Trust.cs
+++ b/Sharphound2/JsonObjects/Trust.cs
@@ -19,6 +19,6 @@
     {
         Inbound = 0,
         Outbound = 1,
-        Bidrectional = 2
+        Bidirectional = 2
     }
 }


### PR DESCRIPTION
Two major changes in this PR:
When enumerating from a child domain, information about trust in the same forest was wrong:
- A trust to the domain itself was collected;
- Trust to the root domain were ignored due to a check in the code, I suppose to ignore trust to itself when enumerating from root domain;
- Trust with other children were displayed as outbound even without cross-link enable.
The PR fix all these things along with many improvement and new trust types (CrossLink and Forest trusts)
Additionally, an iteration though DCs is done to find a pingable DC when enumerating remote domain DC.

Secondly, when enumerating entire forest, code automatically select PDC for LDAP connection with remote domains. In some case, PDCs are not reachable. The proposed fix check if DC is reachable and iterate though DC to find one which can be contacted through LDAP (small modification on DoPing function to add port parameter). The code does not work very well with current connection cache based on server name instead of domain name and could probably be improved, but result will be more accurate if PDC is not reachable but at least one DC is.
