### PR TITLE
Fix removal of non-computer collection methods when ComputerFile is used

### DIFF
--- a/Sharphound2/Sharphound.cs
+++ b/Sharphound2/Sharphound.cs
@@ -601,9 +601,9 @@ General Options
                 }
 
                 Console.WriteLine("ComputerFile detected! Removing non-computer collection methods");
-                resolved = resolved ^ ResolvedCollectionMethod.ACL ^ ResolvedCollectionMethod.Group ^
-                           ResolvedCollectionMethod.GPOLocalGroup ^ ResolvedCollectionMethod.Trusts ^
-                           ResolvedCollectionMethod.Container ^ ResolvedCollectionMethod.ObjectProps;
+                resolved = resolved & ~ResolvedCollectionMethod.ACL & ~ResolvedCollectionMethod.Group
+                           & ~ResolvedCollectionMethod.GPOLocalGroup & ~ResolvedCollectionMethod.Trusts
+                           & ~ResolvedCollectionMethod.Container & ~ResolvedCollectionMethod.ObjectProps;
             }
 
             if (options.Stealth)

--- a/Sharphound2/Sharphound.cs
+++ b/Sharphound2/Sharphound.cs
@@ -611,14 +611,14 @@ General Options
                 if ((resolved & ResolvedCollectionMethod.LocalGroup) != 0)
                 {
                     Console.WriteLine("Note: You specified Stealth and LocalAdmin which is equivalent to GPOLocalGroup");
-                    resolved = resolved ^ ResolvedCollectionMethod.LocalGroup;
+                    resolved = resolved & ~ResolvedCollectionMethod.LocalGroup;
                     resolved = resolved | ResolvedCollectionMethod.GPOLocalGroup;
                 }
 
                 if ((resolved & ResolvedCollectionMethod.LoggedOn) != 0)
                 {
                     Console.WriteLine("LoggedOn enumeration is not supported with Stealth");
-                    resolved = resolved ^ ResolvedCollectionMethod.LoggedOn;
+                    resolved = resolved & ~ResolvedCollectionMethod.LoggedOn;
                 }
             }
 


### PR DESCRIPTION
The binary operator used is incorrect. The intent is to remove the listed collection methods from `resolved` but by using the XOR `^` operator it instead adds these methods (if not already present).
Proof:

```
>SharpHound.exe -c computeronly --computerfile foo.txt
Initializing BloodHound at 11:18 on 28/01/2019
Increasing ping timeout to 1 second for ComputerFile mode
ComputerFile detected! Removing non-computer collection methods
Resolved Collection Methods to Group, LocalGroup, GPOLocalGroup, Session, Trusts, ACL, Container, RDP, ObjectProps, DCOM
```
We see here that several non-computer collection methods were added instead of removed.

The patch replaces XOR by NAND `& ~` operator.
After the patch:
```
>SharpHound.exe -c computeronly --computerfile foo.txt
Initializing BloodHound at 13:09 on 28/01/2019
Increasing ping timeout to 1 second for ComputerFile mode
ComputerFile detected! Removing non-computer collection methods
Resolved Collection Methods to LocalGroup, Session, DCOM
```

Just to be sure that the removal works well, we can try by specifying `all` methods:
```
>SharpHound.exe -c all --computerfile foo.txt
Initializing BloodHound at 13:11 on 28/01/2019
Increasing ping timeout to 1 second for ComputerFile mode
ComputerFile detected! Removing non-computer collection methods
Resolved Collection Methods to LocalGroup, Session, DCOM
```

More info: https://en.wikipedia.org/wiki/Bit_manipulation#Bit_manipulation_in_the_C_programming_language
XOR allows to toggle a bit, but NAND should be used to clear it.