### PR TITLE
Make sure that Computer.Name is always full uppercase

### DIFF
--- a/Sharphound2/Enumeration/EnumerationRunner.cs
+++ b/Sharphound2/Enumeration/EnumerationRunner.cs
@@ -815,6 +815,9 @@ namespace Sharphound2.Enumeration
                         wrapper.Item = null;
                         continue;
                     }
+                    
+                    // make sure to have the computer FQDN in full uppercase, like in other collection methods (non-ComputerFile)
+                    resolved = resolved.ToUpper();
 
                     var netbios = Utils.GetComputerNetbiosName(resolved, out var domain);
                     var temp = _utils.GetDomain(domain);

--- a/Sharphound2/JsonObjects/Computer.cs
+++ b/Sharphound2/JsonObjects/Computer.cs
@@ -4,7 +4,12 @@ namespace Sharphound2.JsonObjects
 {
     internal class Computer : JsonBase
     {
-        public string Name { get; set; }
+        private string _Name;
+        public string Name
+        {
+            get => _Name;
+            set => _Name = value.ToUpper();
+        }
         public string PrimaryGroup { get; set; }
 
         public Dictionary<string, object> Properties = new Dictionary<string, object>();


### PR DESCRIPTION
My situation is the following:
- I've run a domain only collection (-c DcOnly)
- In the computers file, and in neo4j, I have the "COMPUTER.EXAMPLE.COM" computer name
- Then, I run a `-c ComputerOnly` collection, using a `ComputerFile` where I have inputted "computer.example.com" (lower-case, but that's allowed). (Actually it comes from the `dnsHostname` field in AD of the computer I'm targeting.)

What I see is:
- In this last ComputerFile collection, the computers file output has the "computer.example.com" computer name.
- When I import in neo4j with BloodHound UI, it creates two computer objects: the original in full uppercase, the second full lowercase

What I expected is that both computer objects were merged since it's actually the same.

My suggestion is to make sure that Computer.Name is always full uppercase by two ways:
- `Computer` setter which puts it uppercase
- Transforming the `resolved` name in uppercase after resolving it

I've tested successfully the patch.