### PR TITLE
User or Computer not in AD

### DIFF
--- a/Sharphound2/Utils.cs
+++ b/Sharphound2/Utils.cs
@@ -682,7 +682,7 @@ namespace Sharphound2
                 }
                 else
                 {
-                    var context = new DirectoryContext(DirectoryContextType.Domain, domainName);
+                    var context = new DirectoryContext(DirectoryContextType.Domain, domainName, _options.LdapUser, _options.LdapPass);
                     domainObj = Domain.GetDomain(context);
                 }
             }


### PR DESCRIPTION
LDAPUser and LDAPPassword doesn't work, if you use Sharphound at a computer(user) outside of AD.

Problem is in GetDomain:
var context = new DirectoryContext(DirectoryContextType.Domain, domainName); - Api tryed connect this your user credentials. You can see that in Wireshark.

If we use LdapUser, LdapPassword true string is:
var context = new DirectoryContext(DirectoryContextType.Domain, domainName, _options.LdapUser, _options.LdapPass);

