### PR TITLE
Fix issues on trusts collection

### DIFF
--- a/Sharphound2/JsonObjects/Trust.cs
+++ b/Sharphound2/JsonObjects/Trust.cs
@@ -19,6 +19,6 @@
     {
         Inbound = 0,
         Outbound = 1,
-        Bidrectional = 2
+        Bidirectional = 2
     }
 }


### PR DESCRIPTION
This is a shorter version of #51 fixing only issue about trusts collections.

When enumerating from a child domain, information about trust in the same forest were wrong:

- A trust to the domain itself was collected;
- Trust to the root domain were ignored due to a check in the code, I suppose to ignore trust to itself when enumerating from root domain;
- Trust with other children were displayed as outbound even without cross-link enable. 

The PR fix all these things and add new trust types (CrossLink and Forest trusts).