### PR TITLE
Allows running both .Net 3.5 and .Net 4 runtimes

### DIFF
--- a/Sharphound2/App.config
+++ b/Sharphound2/App.config
@@ -1,3 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <startup>
+    <supportedRuntime version="v4.0"/>
+    <supportedRuntime version="v2.0.50727"/>
+  </startup>
 </configuration>


### PR DESCRIPTION
Simple .config fixes to avoid to install .Net 4 framework or to recompile with the framework version changed