### PR TITLE
Added GenericWrite edge for GPOs

### DIFF
--- a/Sharphound2/Enumeration/ACLHelpers.cs
+++ b/Sharphound2/Enumeration/ACLHelpers.cs
@@ -545,6 +545,32 @@ namespace Sharphound2.Enumeration
                     continue;
                 }
 
+                if (rights.HasFlag(ActiveDirectoryRights.GenericWrite) || rights.HasFlag(ActiveDirectoryRights.WriteProperty))
+                {
+                    if (rights.HasFlag(ActiveDirectoryRights.GenericWrite) &&
+                        (objectAceType == AllGuid || objectAceType == ""))
+                    {
+                        aces.Add(new ACL
+                        {
+                            AceType = "",
+                            RightName = "GenericWrite",
+                            PrincipalName = principal.PrincipalName,
+                            PrincipalType = principal.ObjectType
+                        });
+                    }
+                    else if (rights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
+                        (objectAceType == AllGuid || objectAceType == ""))
+                    {
+                        aces.Add(new ACL
+                        {
+                            AceType = "",
+                            RightName = "GenericWrite",
+                            PrincipalName = principal.PrincipalName,
+                            PrincipalType = principal.ObjectType
+                        });
+                    }
+                }
+
                 if (rights.HasFlag(ActiveDirectoryRights.WriteDacl))
                 {
                     aces.Add(new ACL


### PR DESCRIPTION
SharpHound currently does not detect Edit Settings permissions on a GPO. However, this level of access can be used as part of an attack path.

![image](https://user-images.githubusercontent.com/25517393/62122522-cbd7ee80-b2bd-11e9-8dcb-3eead52ed878.png)

The current version of SharpHound generates the following:

![before_genericwrite](https://user-images.githubusercontent.com/25517393/62121743-2bcd9580-b2bc-11e9-9d2a-704be102f34b.PNG)

After the changes the graph includes the 2 more users:

![after_genericwrite](https://user-images.githubusercontent.com/25517393/62121736-27a17800-b2bc-11e9-8db9-019516deaedd.PNG)

I hope this helps.

Thanks
