### PR TITLE
Add collection for Remote Management Users

### DIFF
--- a/Sharphound2/App.config
+++ b/Sharphound2/App.config
@@ -1,3 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Sharphound2/Enumeration/EnumerationRunner.cs
+++ b/Sharphound2/Enumeration/EnumerationRunner.cs
@@ -949,6 +949,14 @@ namespace Sharphound2.Enumeration
                     {
                         timeout = true;
                     }
+                    try
+                    {
+                        obj.RemoteManagementUsers = LocalGroupHelpers.GetGroupMembers(full, LocalGroupHelpers.LocalGroupRids.RemoteManagementUsers).ToArray();
+                    }
+                    catch (TimeoutException)
+                    {
+                        timeout = true;
+                    }
 
                     try
                     {
@@ -1131,6 +1139,16 @@ namespace Sharphound2.Enumeration
                             {
                                 obj.DcomUsers = LocalGroupHelpers.GetGroupMembers(resolved,
                                     LocalGroupHelpers.LocalGroupRids.DcomUsers).ToArray();
+                            }
+                            catch (TimeoutException)
+                            {
+                                timeout = true;
+                            }
+
+                            try
+                            {
+                                obj.RemoteManagementUsers = LocalGroupHelpers.GetGroupMembers(resolved,
+                                    LocalGroupHelpers.LocalGroupRids.RemoteManagementUsers).ToArray();
                             }
                             catch (TimeoutException)
                             {

--- a/Sharphound2/Enumeration/LocalGroupHelpers.cs
+++ b/Sharphound2/Enumeration/LocalGroupHelpers.cs
@@ -254,6 +254,9 @@ namespace Sharphound2.Enumeration
             if (rid.Equals(LocalGroupRids.DcomUsers) && !Utils.IsMethodSet(ResolvedCollectionMethod.DCOM))
                 yield break;
 
+            if (rid.Equals(LocalGroupRids.RemoteManagementUsers) && !Utils.IsMethodSet(ResolvedCollectionMethod.LocalAdmin)) //TODO add proper collection method
+                yield break;
+
             Utils.Debug("Starting GetSamAdmins");
             string machineSid = null;
             Utils.Debug("Starting Task");
@@ -785,6 +788,11 @@ namespace Sharphound2.Enumeration
                     {
                         Name = x.Name,
                         Type = x.Type
+                    }).ToArray(),
+                    RemoteManagementUsers = resolvedList.Where((x) => x.RID == 580).Select((x) => new LocalMember
+                    {
+                        Name = x.Name,
+                        Type = x.Type
                     }).ToArray()
                 };
 
@@ -848,7 +856,8 @@ namespace Sharphound2.Enumeration
         {
             Administrators = 544,
             RemoteDesktopUsers = 555,
-            DcomUsers = 562
+            DcomUsers = 562,
+            RemoteManagementUsers = 580
         }
 
         #region LSA Imports

--- a/Sharphound2/JsonObjects/Computer.cs
+++ b/Sharphound2/JsonObjects/Computer.cs
@@ -17,6 +17,7 @@ namespace Sharphound2.JsonObjects
         public LocalMember[] LocalAdmins { get; set; }
         public LocalMember[] RemoteDesktopUsers { get; set; }
         public LocalMember[] DcomUsers { get; set; }
+        public LocalMember[] RemoteManagementUsers { get; set; }
         public string[] AllowedToDelegate { get; set; }
         public LocalMember[] AllowedToAct { get; set; }
         public ACL[] Aces { get; set; }

--- a/Sharphound2/JsonObjects/GpoMember.cs
+++ b/Sharphound2/JsonObjects/GpoMember.cs
@@ -6,5 +6,6 @@
         public LocalMember[] RemoteDesktopUsers { get; set; }
         public LocalMember[] LocalAdmins { get; set; }
         public LocalMember[] DcomUsers { get; set; }
+        public LocalMember[] RemoteManagementUsers { get; set; }
     }
 }

--- a/Sharphound2/Sharphound2.csproj
+++ b/Sharphound2/Sharphound2.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Sharphound2</RootNamespace>
     <AssemblyName>SharpHound</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -22,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,9 +33,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <ApplicationIcon>favicon.ico</ApplicationIcon>
+    <ApplicationIcon>
+    </ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">


### PR DESCRIPTION
I added support for collecting local membership of the group "Remote Management Users", which can be used to define users that can access a target machine using PowerShell remoting.

For example, I am pushing the group "Domain Users" in the local group "Remote Management Users", as it is possible to see in the screenshot below from my test domain:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/20563462/62835924-b2d42380-bc55-11e9-9ce5-a69278743e48.png">

and, as you can see, the user RANCARANI is able to `Enter-PSSession` in the domain controller:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/20563462/62835981-3ee64b00-bc56-11e9-86f2-ae578b270a00.png">

The result within BloodHound is the following:

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/20563462/62836014-a69c9600-bc56-11e9-9410-eefd44b41874.png">

I added the edge `CanPSRemote` .

I will create the pull request for the Electron app as soon as I can.

